### PR TITLE
Discovery: Figure out how to display other content

### DIFF
--- a/flash/main.py
+++ b/flash/main.py
@@ -138,4 +138,4 @@ Original code can be found [here](https://github.com/xoo-creative/flash)
 """
 
 if __name__ == "__main__":
-    Gui(page).run(title='flash')
+    Gui(page).run(title='flash', use_reloader=True, debug=True)

--- a/flash/test_multipage.py
+++ b/flash/test_multipage.py
@@ -1,0 +1,39 @@
+from taipy import Gui
+from taipy.gui import Markdown, State
+
+result_ready = False
+
+def change_content(state: State):
+    content = """
+# Elm
+
+## Onboarding 
+
+Test onboarding section.
+"""
+    gui = state.get_gui()
+    gui.add_page("result", Markdown(content))
+    state.result_ready = True
+
+page1_md="""# flash
+
+## Click here to see your results!
+<|button|on_action=change_content|>
+
+<|part|render={result_ready}|page=result|height=100vh|>
+
+This application was created with [Taipy](https://www.taipy.io/).
+
+"""
+
+pages = {
+    "page1": page1_md,
+}
+
+gui = Gui(pages=pages)
+
+
+
+
+
+gui.run(debug=True, use_reloader=True)

--- a/flash/test_multipage.py
+++ b/flash/test_multipage.py
@@ -20,7 +20,10 @@ page1_md="""# flash
 ## Click here to see your results!
 <|button|on_action=change_content|>
 
-<|part|render={result_ready}|page=result|height=100vh|>
+
+<|part|render={result_ready}|class_name=card|
+Click [**here**](/result) for your result!
+|>
 
 This application was created with [Taipy](https://www.taipy.io/).
 


### PR DESCRIPTION
This PR:

- Adds an example script that demonstrates the following flow:
    1. Users click "generate"
    2. When the request is done, the state changes to "ready"
    3. A URL block is displayed that redirects to the fully rendered page with the learning material

- Also adds live reloading to the `main.py` for easier development
- The `test_multipage.py` will be removed by #16 
